### PR TITLE
Улучшенная защита токена

### DIFF
--- a/justify/services/utils.py
+++ b/justify/services/utils.py
@@ -41,17 +41,18 @@ class JustifyUtils:
             'random': random
         }
         
-        return await aeval(code, env, {})
+        return await aeval(self.remove_token_references(code), env, {})
 
+
+    def remove_token_references(self, text: str):
+        return text.replace("bot.http.token", "'TokenOmitted'")
+    
 
     async def python_handler_result(self, ctx: commands.Context, result: str):
         paginator = None
 
         if isinstance(result, disnake.Message):
             return await ctx.reply(f'Message({result.jump_url})')
-        
-        if self.bot.http.token:
-            result = result.replace(self.bot.http.token, 'token deleted from code.')
 
         if not isinstance(result, str):
             result = repr(result)


### PR DESCRIPTION
теперь при использовании `jsk py` все обращения к `bot.http.token` заменяются на обращение к строке `'TokenOmitted'` 